### PR TITLE
Temporary ipywidgets pin to get CI working for now

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,7 +39,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
           miniforge-variant: Mambaforge
           environment-file: environment.yml
-          activate-environment: openfe-benchmarks
+          activate-environment: mdml_workshop
  
       - name: "environment information"
         run: |

--- a/environment.yml
+++ b/environment.yml
@@ -14,3 +14,4 @@ dependencies:
   # testing
   - pytest
   - nbval
+  - ipywidgets<8


### PR DESCRIPTION
It's been > week and with recent talks of things related to workshops I thought it might be good to at least get the env working for now so folks aren't hindered if they start looking through things here - (we can unpin once fixed?)